### PR TITLE
Update .travis.yml to use openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: java
 
-jdk:
-  - oraclejdk8
+jdk: openjdk8
 
 sudo: false
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer


### PR DESCRIPTION
Because of https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802 Travis builds will fail by default (unless you use openjdk8 or Ubuntu Trusty)